### PR TITLE
feat: player comparison, rating history, and automated snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,20 @@
-# Discord Bot Token
-DISCORD_TOKEN=your_discord_bot_token_here
+# Discord Bot Configuration
+# Copy this file to .env and fill in your values
 
-# Tracker.gg API Key
+# Required
+DISCORD_TOKEN=your_discord_bot_token_here
 TRACKER_GG_API_KEY=your_tracker_gg_api_key_here
 
-# Redis Configuration (Optional)
+# Redis Configuration (optional)
 REDIS_URL=redis://localhost:6379
 
-# Bot Configuration
-PREFIX=!v
+# Logging (optional)
+LOG_LEVEL=info
+
+# Rate Limiting (optional)
 MAX_API_REQUESTS_PER_MINUTE=60
 RATE_LIMIT_WINDOW_MS=60000
 
-# Logging
-LOG_LEVEL=info
-
-# Optional: Analytics
-ENABLE_ANALYTICS=true
-ANALYTICS_DB_PATH=./analytics.db
+# Snapshot Scheduler (optional)
+CRON_SNAPSHOT_INTERVAL_HOURS=6
+SNAPSHOT_RETENTION_DAYS=30

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,0 +1,78 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
+import { getValorantStats } from "../services/tracker";
+import logger from "../logger";
+
+export const data = new SlashCommandBuilder()
+ .setName("compare")
+ .setDescription("Compare Valorant stats between two players")
+ .addStringOption((opt) =>
+ opt
+ .setName("player1")
+ .setDescription("First player Riot ID (username#tag)")
+ .setRequired(true)
+ )
+ .addStringOption((opt) =>
+ opt
+ .setName("player2")
+ .setDescription("Second player Riot ID (username#tag)")
+ .setRequired(true)
+ );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+ await interaction.deferReply();
+ const player1Id = interaction.options.getString("player1", true);
+ const player2Id = interaction.options.getString("player2", true);
+
+ const [p1Name, p1Tag] = player1Id.split("#");
+ const [p2Name, p2Tag] = player2Id.split("#");
+
+ if (!p1Name || !p1Tag || !p2Name || !p2Tag) {
+ await interaction.editReply("❌ Both IDs must be in format `username#tag`.");
+ return;
+ }
+
+ try {
+ const [stats1, stats2] = await Promise.all([
+ getValorantStats(p1Name, p1Tag),
+ getValorantStats(p2Name, p2Tag)
+ ]);
+
+ const kd1 = (stats1.stats.kills / Math.max(1, stats1.stats.deaths)).toFixed(2);
+ const kd2 = (stats2.stats.kills / Math.max(1, stats2.stats.deaths)).toFixed(2);
+ const winRate1 = ((stats1.stats.wins / Math.max(1, stats1.stats.matchesPlayed)) * 100).toFixed(1);
+ const winRate2 = ((stats2.stats.wins / Math.max(1, stats2.stats.matchesPlayed)) * 100).toFixed(1);
+
+ const embed = {
+ title: "⚔️ Valorant Stats Comparison",
+ color: 0xff6b6b,
+ fields: [
+ { name: "Metric", value: "Player", inline: true },
+ { name: "\u200B", value: "Value", inline: true },
+ { name: "\u200B", value: "Winner", inline: true },
+ 
+ { name: "Player", value: `${stats1.username}#${stats1.tag}\n${stats2.username}#${stats2.tag}`, inline: true },
+ { name: "Rating", value: `${stats1.stats.rating}\n${stats2.stats.rating}`, inline: true },
+ { name: "\u200B", value: `${stats1.stats.rating > stats2.stats.rating ? "👑 P1" : stats2.stats.rating > stats1.stats.rating ? "👑 P2" : "🤝 Tie"}`, inline: true },
+ 
+ { name: "\u200B", value: "K/D Ratio", inline: true },
+ { name: "\u200B", value: `${kd1}\n${kd2}`, inline: true },
+ { name: "\u200B", value: `${parseFloat(kd1) > parseFloat(kd2) ? "👑 P1" : parseFloat(kd2) > parseFloat(kd1) ? "👑 P2" : "🤝 Tie"}`, inline: true },
+ 
+ { name: "\u200B", value: "Win Rate", inline: true },
+ { name: "\u200B", value: `${winRate1}%\n${winRate2}%`, inline: true },
+ { name: "\u200B", value: `${parseFloat(winRate1) > parseFloat(winRate2) ? "👑 P1" : parseFloat(winRate2) > parseFloat(winRate1) ? "👑 P2" : "🤝 Tie"}`, inline: true },
+ 
+ { name: "\u200B", value: "Headshots", inline: true },
+ { name: "\u200B", value: `${stats1.stats.headshots}\n${stats2.stats.headshots}`, inline: true },
+ { name: "\u200B", value: `${stats1.stats.headshots > stats2.stats.headshots ? "👑 P1" : stats2.stats.headshots > stats1.stats.headshots ? "👑 P2" : "🤝 Tie"}`, inline: true },
+ ],
+ footer: { text: "Data powered by Tracker.gg" },
+ timestamp: new Date().toISOString(),
+ };
+
+ await interaction.editReply({ embeds: [embed] });
+ } catch (err: any) {
+ logger.warn(err.message);
+ await interaction.editReply(`❌ ${err.message}`);
+ }
+}

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,90 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
+import { getValorantStats } from "../services/tracker";
+import { saveSnapshot, getSnapshots, getLatestSnapshot } from "../services/persistence";
+import logger from "../logger";
+
+export const data = new SlashCommandBuilder()
+ .setName("history")
+ .setDescription("View rating history for a player")
+ .addStringOption((opt) =>
+ opt
+ .setName("riot_id")
+ .setDescription("Riot ID in the format username#tag")
+ .setRequired(true)
+ )
+ .addIntegerOption((opt) =>
+ opt
+ .setName("days")
+ .setDescription("Number of days to show (default: 7)")
+ .setMinValue(1)
+ .setMaxValue(30)
+ );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+ await interaction.deferReply();
+ const riotId = interaction.options.getString("riot_id", true);
+ const days = interaction.options.getInteger("days") || 7;
+ const [username, tag] = riotId.split("#");
+
+ if (!username || !tag) {
+ await interaction.editReply("❌ Please provide the Riot ID in the format `username#tag`.");
+ return;
+ }
+
+ try {
+ // Fetch current stats and save snapshot
+ const currentStats = await getValorantStats(username, tag);
+ await saveSnapshot({
+ username,
+ tag,
+ timestamp: Date.now(),
+ stats: currentStats.stats
+ });
+
+ // Get historical snapshots
+ const allSnapshots = await getSnapshots(username, tag, 30);
+ const cutoff = Date.now() - (days * 24 * 60 * 60 * 1000);
+ const recentSnapshots = allSnapshots.filter(s => s.timestamp >= cutoff);
+
+ if (recentSnapshots.length === 0) {
+ await interaction.editReply("📊 No historical data available yet. Check back tomorrow!");
+ return;
+ }
+
+ // Calculate rating change
+ const oldest = recentSnapshots[0];
+ const newest = recentSnapshots[recentSnapshots.length - 1];
+ const ratingChange = newest.stats.rating - oldest.stats.rating;
+ const changeEmoji = ratingChange > 0 ? "📈" : ratingChange < 0 ? "📉" : "➡️";
+
+ // Build simple text-based chart
+ const maxRating = Math.max(...recentSnapshots.map(s => s.stats.rating));
+ const minRating = Math.min(...recentSnapshots.map(s => s.stats.rating));
+ const range = Math.max(1, maxRating - minRating);
+ 
+ const chartLines = recentSnapshots.map(s => {
+ const normalized = ((s.stats.rating - minRating) / range) * 20;
+ const bar = "▇".repeat(Math.max(1, Math.floor(normalized)));
+ const date = new Date(s.timestamp).toLocaleDateString();
+ return `\`${date}\` \`\`${s.stats.rating.toString().padStart(4)}\`\` ${bar}`;
+ }).join("\n");
+
+ const embed = {
+ title: `📊 Rating History - ${username}#${tag}`,
+ description: `**${changeEmoji} Rating change: ${ratingChange > 0 ? "+" : ""}${ratingChange.toFixed(1)}** over ${days} day(s)\n\n${chartLines}`,
+ color: ratingChange > 0 ? 0x00ff00 : ratingChange < 0 ? 0xff0000 : 0x7289da,
+ fields: [
+ { name: "Current Rating", value: `${newest.stats.rating}`, inline: true },
+ { name: "Peak Rating", value: `${maxRating}`, inline: true },
+ { name: "Total Matches", value: `${newest.stats.matchesPlayed}`, inline: true },
+ ],
+ footer: { text: `Showing ${recentSnapshots.length} data point(s)` },
+ timestamp: new Date().toISOString(),
+ };
+
+ await interaction.editReply({ embeds: [embed] });
+ } catch (err: any) {
+ logger.warn(err.message);
+ await interaction.editReply(`❌ ${err.message}`);
+ }
+}

--- a/src/commands/valorant.ts
+++ b/src/commands/valorant.ts
@@ -1,49 +1,50 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
 import { getValorantStats } from "../services/tracker";
+import { addActivePlayer } from "../scheduler";
 import logger from "../logger";
 
-/**
- * `/valorant <user>` – fetches Valorant stats for a Riot ID (e.g. `player#NA1`).
- * The command parses the tag automatically – you can provide `username#tag` or separate args.
- */
 export const data = new SlashCommandBuilder()
-  .setName("valorant")
-  .setDescription("Get Valorant player statistics")
-  .addStringOption((opt) =>
-    opt
-      .setName("riot_id")
-      .setDescription("Riot ID in the form username#tag (e.g. shy#NA1)")
-      .setRequired(true)
-  );
+ .setName("valorant")
+ .setDescription("Get Valorant player statistics")
+ .addStringOption((opt) =>
+ opt
+ .setName("riot_id")
+ .setDescription("Riot ID in the form username#tag (e.g. shy#NA1)")
+ .setRequired(true)
+ );
 
 export async function execute(interaction: ChatInputCommandInteraction) {
-  await interaction.deferReply();
-  const riotId = interaction.options.getString("riot_id", true);
-  const [username, tag] = riotId.split("#");
+ await interaction.deferReply();
+ const riotId = interaction.options.getString("riot_id", true);
+ const [username, tag] = riotId.split("#");
 
-  if (!username || !tag) {
-    await interaction.editReply("❌ Please provide the Riot ID in the format `username#tag`.");
-    return;
-  }
+ if (!username || !tag) {
+ await interaction.editReply("❌ Please provide the Riot ID in the format `username#tag`.");
+ return;
+ }
 
-  try {
-    const stats = await getValorantStats(username, tag);
-    const embed = {
-      title: `${stats.username}#${stats.tag} – Valorant Stats`,
-      color: 0x7289da,
-      fields: [
-        { name: "Rating", value: String(stats.stats.rating), inline: true },
-        { name: "Matches Played", value: String(stats.stats.matchesPlayed), inline: true },
-        { name: "Wins", value: String(stats.stats.wins), inline: true },
-        { name: "K/D/A", value: `${stats.stats.kills}/${stats.stats.deaths}/${stats.stats.assists}`, inline: true },
-        { name: "Headshots", value: String(stats.stats.headshots), inline: true },
-      ],
-      footer: { text: "Data powered by Tracker.gg" },
-      timestamp: new Date().toISOString(),
-    };
-    await interaction.editReply({ embeds: [embed] });
-  } catch (err: any) {
-    logger.warn(err.message);
-    await interaction.editReply(`❌ ${err.message}`);
-  }
+ try {
+ const stats = await getValorantStats(username, tag);
+ 
+ // Track this player for automated snapshots
+ addActivePlayer(username, tag);
+ 
+ const embed = {
+ title: `${stats.username}#${stats.tag} – Valorant Stats`,
+ color: 0x7289da,
+ fields: [
+ { name: "Rating", value: String(stats.stats.rating), inline: true },
+ { name: "Matches Played", value: String(stats.stats.matchesPlayed), inline: true },
+ { name: "Wins", value: String(stats.stats.wins), inline: true },
+ { name: "K/D/A", value: `${stats.stats.kills}/${stats.stats.deaths}/${stats.stats.assists}`, inline: true },
+ { name: "Headshots", value: String(stats.stats.headshots), inline: true },
+ ],
+ footer: { text: "Data powered by Tracker.gg" },
+ timestamp: new Date().toISOString(),
+ };
+ await interaction.editReply({ embeds: [embed] });
+ } catch (err: any) {
+ logger.warn(err.message);
+ await interaction.editReply(`❌ ${err.message}`);
+ }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,56 +7,54 @@ import fs from "fs/promises";
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection<string, any>();
 
-// Dynamically load command modules
 async function loadCommands() {
-  const commandsPath = path.join(import.meta.dirname, "commands");
-  const files = await fs.readdir(commandsPath);
-  const commandData = [];
-  for (const file of files) {
-    if (!file.endsWith(".ts")) continue;
-    const modulePath = path.join(commandsPath, file);
-    const command = await import(modulePath);
-    client.commands.set(command.data.name, command);
-    commandData.push(command.data.toJSON());
-  }
-  // Register slash commands globally (could be scoped to guild for testing)
-  const rest = new REST({ version: "10" }).setToken(CONFIG.DISCORD_TOKEN);
-  try {
-    logger.info("Started refreshing application (/) commands.");
-    await rest.put(Routes.applicationCommands(client.user!.id), { body: commandData });
-    logger.info("Successfully reloaded application (/) commands.");
-  } catch (error) {
-    logger.error("Error registering commands: %s", (error as any).message);
-  }
+ const commandsPath = path.join(import.meta.dirname, "commands");
+ const files = await fs.readdir(commandsPath);
+ const commandData = [];
+ for (const file of files) {
+ if (!file.endsWith(".ts")) continue;
+ const modulePath = path.join(commandsPath, file);
+ const command = await import(modulePath);
+ client.commands.set(command.data.name, command);
+ commandData.push(command.data.toJSON());
+ }
+ const rest = new REST({ version: "10" }).setToken(CONFIG.DISCORD_TOKEN);
+ try {
+ logger.info("Started refreshing application (/) commands.");
+ await rest.put(Routes.applicationCommands(client.user!.id), { body: commandData });
+ logger.info("Successfully reloaded application (/) commands.");
+ } catch (error) {
+ logger.error("Error registering commands: %s", (error as any).message);
+ }
 }
 
 client.once(Events.ClientReady, async () => {
-  logger.info("Bot logged in as %s", client.user!.tag);
-  await loadCommands();
+ logger.info("Bot logged in as %s", client.user!.tag);
+ await loadCommands();
 });
 
 client.on(Events.InteractionCreate, async (interaction: Interaction) => {
-  if (!interaction.isChatInputCommand()) return;
-  const command = client.commands.get(interaction.commandName);
-  if (!command) return;
-  try {
-    await command.execute(interaction);
-  } catch (error) {
-    logger.error("Command execution error: %s", (error as any).message);
-    if (interaction.replied || interaction.deferred) {
-      await interaction.editReply({ content: "❌ Something went wrong while executing the command.", embeds: [] });
-    } else {
-      await interaction.reply({ content: "❌ Something went wrong while executing the command.", ephemeral: true });
-    }
-  }
+ if (!interaction.isChatInputCommand()) return;
+ const command = client.commands.get(interaction.commandName);
+ if (!command) return;
+ try {
+ await command.execute(interaction);
+ } catch (error) {
+ logger.error("Command execution error: %s", (error as any).message);
+ if (interaction.replied || interaction.deferred) {
+ await interaction.editReply({ content: "❌ Something went wrong while executing the command.", embeds: [] });
+ } else {
+ await interaction.reply({ content: "❌ Something went wrong while executing the command.", ephemeral: true });
+ }
+ }
 });
 
 process.on("unhandledRejection", (reason) => {
-  logger.error("Unhandled Rejection: %s", reason);
+ logger.error("Unhandled Rejection: %s", reason);
 });
 process.on("uncaughtException", (err) => {
-  logger.error("Uncaught Exception: %s", err);
-  process.exit(1);
+ logger.error("Uncaught Exception: %s", err);
+ process.exit(1);
 });
 
 client.login(CONFIG.DISCORD_TOKEN);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Client, Collection, Events, GatewayIntentBits, Interaction, REST, Routes } from "discord.js";
 import logger from "./logger";
 import { CONFIG } from "./config";
+import { startSnapshotScheduler } from "./scheduler";
 import path from "path";
 import fs from "fs/promises";
 
@@ -31,6 +32,7 @@ async function loadCommands() {
 client.once(Events.ClientReady, async () => {
  logger.info("Bot logged in as %s", client.user!.tag);
  await loadCommands();
+ startSnapshotScheduler();
 });
 
 client.on(Events.InteractionCreate, async (interaction: Interaction) => {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,85 @@
+import cron from "node-cron";
+import { saveSnapshot, cleanupOldSnapshots } from "./services/persistence";
+import logger from "./logger";
+
+const ACTIVE_PLAYERS_KEY = "active_players";
+
+export interface ActivePlayer {
+ username: string;
+ tag: string;
+ lastQueried: number;
+}
+
+export function addActivePlayer(username: string, tag: string): void {
+ const player: ActivePlayer = {
+ username,
+ tag,
+ lastQueried: Date.now()
+ };
+ 
+ // This would ideally use Redis, but using in-memory for simplicity
+ // In production, use Redis set with TTL
+ const activePlayers = getActivePlayers();
+ const existingIndex = activePlayers.findIndex(p => p.username.toLowerCase() === username.toLowerCase() && p.tag === tag);
+ 
+ if (existingIndex >= 0) {
+ activePlayers[existingIndex] = player;
+ } else {
+ activePlayers.push(player);
+ }
+ 
+ // Keep only last 50 active players to prevent memory bloat
+ if (activePlayers.length > 50) {
+ activePlayers.sort((a, b) => b.lastQueried - a.lastQueried);
+ activePlayers.splice(50);
+ }
+ 
+ (global as any).__activePlayers = activePlayers;
+ logger.debug("Added %s#%s to active players", username, tag);
+}
+
+export function getActivePlayers(): ActivePlayer[] {
+ return (global as any).__activePlayers || [];
+}
+
+export function startSnapshotScheduler(): void {
+ // Take snapshots of active players every 6 hours
+ cron.schedule("0 */6 * * *", async () => {
+ logger.info("Starting scheduled snapshot collection");
+ const players = getActivePlayers();
+ 
+ for (const player of players) {
+ try {
+ const { getValorantStats } = await import("./services/tracker");
+ const stats = await getValorantStats(player.username, player.tag);
+ await saveSnapshot({
+ username: player.username,
+ tag: player.tag,
+ timestamp: Date.now(),
+ stats: stats.stats
+ });
+ logger.debug("Scheduled snapshot saved for %s#%s", player.username, player.tag);
+ } catch (err) {
+ logger.error("Failed to snapshot %s#%s: %s", player.username, player.tag, (err as any).message);
+ }
+ }
+ 
+ logger.info("Completed scheduled snapshot collection for %d players", players.length);
+ });
+
+ // Cleanup old snapshots daily
+ cron.schedule("0 0 * * *", async () => {
+ logger.info("Starting daily snapshot cleanup");
+ const players = getActivePlayers();
+ let totalCleaned = 0;
+ 
+ for (const player of players) {
+ const cleaned = await cleanupOldSnapshots(player.username, player.tag);
+ totalCleaned += cleaned;
+ }
+ 
+ logger.info("Cleaned up %d old snapshots during daily cleanup", totalCleaned);
+ });
+
+ logger.info("Snapshot scheduler started (every 6 hours)");
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,6 +3,8 @@ import { saveSnapshot, cleanupOldSnapshots } from "./services/persistence";
 import logger from "./logger";
 
 const ACTIVE_PLAYERS_KEY = "active_players";
+const SNAPSHOT_INTERVAL_HOURS = parseInt(process.env.CRON_SNAPSHOT_INTERVAL_HOURS || "6");
+const SNAPSHOT_RETENTION_DAYS = parseInt(process.env.SNAPSHOT_RETENTION_DAYS || "30");
 
 export interface ActivePlayer {
  username: string;
@@ -17,8 +19,6 @@ export function addActivePlayer(username: string, tag: string): void {
  lastQueried: Date.now()
  };
  
- // This would ideally use Redis, but using in-memory for simplicity
- // In production, use Redis set with TTL
  const activePlayers = getActivePlayers();
  const existingIndex = activePlayers.findIndex(p => p.username.toLowerCase() === username.toLowerCase() && p.tag === tag);
  
@@ -28,7 +28,6 @@ export function addActivePlayer(username: string, tag: string): void {
  activePlayers.push(player);
  }
  
- // Keep only last 50 active players to prevent memory bloat
  if (activePlayers.length > 50) {
  activePlayers.sort((a, b) => b.lastQueried - a.lastQueried);
  activePlayers.splice(50);
@@ -43,8 +42,9 @@ export function getActivePlayers(): ActivePlayer[] {
 }
 
 export function startSnapshotScheduler(): void {
- // Take snapshots of active players every 6 hours
- cron.schedule("0 */6 * * *", async () => {
+ const cronPattern = `0 */${SNAPSHOT_INTERVAL_HOURS} * * *`;
+ 
+ cron.schedule(cronPattern, async () => {
  logger.info("Starting scheduled snapshot collection");
  const players = getActivePlayers();
  
@@ -67,19 +67,19 @@ export function startSnapshotScheduler(): void {
  logger.info("Completed scheduled snapshot collection for %d players", players.length);
  });
 
- // Cleanup old snapshots daily
  cron.schedule("0 0 * * *", async () => {
  logger.info("Starting daily snapshot cleanup");
  const players = getActivePlayers();
  let totalCleaned = 0;
+ const maxAgeMs = SNAPSHOT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
  
  for (const player of players) {
- const cleaned = await cleanupOldSnapshots(player.username, player.tag);
+ const cleaned = await cleanupOldSnapshots(player.username, player.tag, maxAgeMs);
  totalCleaned += cleaned;
  }
  
  logger.info("Cleaned up %d old snapshots during daily cleanup", totalCleaned);
  });
 
- logger.info("Snapshot scheduler started (every 6 hours)");
+ logger.info("Snapshot scheduler started (every %d hours, retention %d days)", SNAPSHOT_INTERVAL_HOURS, SNAPSHOT_RETENTION_DAYS);
 }

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -1,0 +1,71 @@
+import { createClient } from "redis";
+import logger from "../logger";
+
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+const redis = createClient({ url: REDIS_URL });
+
+redis.on("error", (err) => logger.error("Redis error: %s", err));
+
+let connected = false;
+
+async function ensureConnected() {
+ if (!connected) {
+ await redis.connect();
+ connected = true;
+ }
+}
+
+export interface PlayerSnapshot {
+ username: string;
+ tag: string;
+ timestamp: number;
+ stats: {
+ rating: number;
+ matchesPlayed: number;
+ wins: number;
+ kills: number;
+ deaths: number;
+ assists: number;
+ headshots: number;
+ };
+}
+
+export async function saveSnapshot(snapshot: PlayerSnapshot): Promise<void> {
+ await ensureConnected();
+ const key = `snapshot:${snapshot.username.toLowerCase()}:${snapshot.tag}:${snapshot.timestamp}`;
+ await redis.set(key, JSON.stringify(snapshot));
+ await redis.zAdd(`snapshots:${snapshot.username.toLowerCase()}:${snapshot.tag}`, {
+ score: snapshot.timestamp,
+ value: String(snapshot.timestamp),
+ });
+ logger.debug("Saved snapshot for %s#%s", snapshot.username, snapshot.tag);
+}
+
+export async function getLatestSnapshot(username: string, tag: string): Promise<PlayerSnapshot | null> {
+ await ensureConnected();
+ const key = `snapshots:${username.toLowerCase()}:${tag}`;
+ const result = await redis.zRange(key, -1, -1);
+ if (!result.length) return null;
+ const latestTs = result[0];
+ const data = await redis.get(`snapshot:${username.toLowerCase()}:${tag}:${latestTs}`);
+ return data ? JSON.parse(data) : null;
+}
+
+export async function getSnapshots(username: string, tag: string, limit = 30): Promise<PlayerSnapshot[]> {
+ await ensureConnected();
+ const key = `snapshots:${username.toLowerCase()}:${tag}`;
+ const results = await redis.zRange(key, -limit, -1);
+ if (!results.length) return [];
+ const keys = results.map((ts) => `snapshot:${username.toLowerCase()}:${tag}:${ts}`);
+ const data = await redis.mGet(keys);
+ return data.filter(Boolean).map((d) => JSON.parse(d as string));
+}
+
+export async function cleanupOldSnapshots(username: string, tag: string, maxAgeMs = 30 * 24 * 60 * 60 * 1000): Promise<number> {
+ await ensureConnected();
+ const cutoff = Date.now() - maxAgeMs;
+ const key = `snapshots:${username.toLowerCase()}:${tag}`;
+ const removed = await redis.zRemRangeByScore(key, 0, cutoff);
+ logger.info("Cleaned up %d old snapshots for %s#%s", removed, username, tag);
+ return removed;
+}


### PR DESCRIPTION
## What
Added three major features to enhance the Valorant stats bot:

1. **Player Comparison** (`/compare`) - Compare stats between two players side-by-side with winner indicators
2. **Rating History** (`/history`) - View rating progression over time with text-based charts
3. **Automated Snapshots** - Background service that saves player stats every 6 hours for active players

## Why
These features provide deeper insights for users:
- Compare allows friendly competition between players
- History shows progression and trends over time
- Automated snapshots ensure data is collected even when users don't manually check stats

## Changes
- Added `/compare` command with K/D ratio and win rate calculations
- Added `/history` command with text-based rating charts
- Created persistence layer (`src/services/persistence.ts`) for Redis-based snapshot storage
- Added scheduler (`src/scheduler.ts`) for automated snapshot collection (every 6 hours)
- Enhanced `/valorant` command to track active players for snapshots
- Made scheduler configurable via environment variables
- Updated `.env.example` with new configuration options

## Technical Details
- Snapshots stored in Redis with 30-day retention (configurable)
- Active player tracking limited to 50 most recent to prevent memory bloat
- Parallel data fetching for comparison command
- Automatic cleanup of old snapshots
- Type-safe snapshot interfaces

## Testing
1. Run `/valorant player#tag` - verifies active player tracking
2. Run `/compare player1#tag player2#tag` - compares two players
3. Run `/history player#tag` - shows rating history (will initially show no data)
4. Wait for scheduled snapshots or use the bot multiple times to generate data
5. Check logs for scheduler: "Snapshot scheduler started (every 6 hours)"

## Configuration
New environment variables:
- `CRON_SNAPSHOT_INTERVAL_HOURS=6` - How often to take snapshots
- `SNAPSHOT_RETENTION_DAYS=30` - How long to keep old snapshots